### PR TITLE
Add support for rpc-host-whitelist settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,16 @@ There are no mandatory variables.
 
 ### Web interface & RPC
 
-| Variable                             | Default                 |
-| ------------------------------------ | ----------------------- |
-| `transmission_password`              |                         |
-| `transmission_rpc_auth_required`     | `false`                 |
-| `transmission_user`                  | `{{ ansible_user_id }}` |
-| `transmission_rpc_whitelist_enabled` | `false`                 |
-| `transmission_rpc_whitelist`         | `127.0.0.1`             |
-| `transmission_url`                   | `/transmission/`        |
+| Variable                                  | Default                 |
+| ----------------------------------------- | ----------------------- |
+| `transmission_password`                   |                         |
+| `transmission_rpc_auth_required`          | `false`                 |
+| `transmission_user`                       | `{{ ansible_user_id }}` |
+| `transmission_rpc_whitelist_enabled`      | `true`                  |
+| `transmission_rpc_whitelist`              | `127.0.0.1`             |
+| `transmission_rpc_host_whitelist_enabled` | `true`                  |
+| `transmission_rpc_host_whitelist`         | `""`                    |
+| `transmission_url`                        | `/transmission/`        |
 
 ### Folders
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@ transmission_rpc_auth_enabled: true
 transmission_rpc_whitelist_enabled: true
 transmission_rpc_whitelist: 127.0.0.1
 transmission_rpc_auth_required: false
+transmission_rpc_host_whitelist_enabled: true
+transmission_rpc_host_whitelist: ""
 
 transmission_umask: 2
 

--- a/templates/settings.json.j2
+++ b/templates/settings.json.j2
@@ -54,6 +54,8 @@
     "rpc-username": "{{ transmission_user }}",
     "rpc-whitelist": "{{ transmission_rpc_whitelist }}",
     "rpc-whitelist-enabled": {{ transmission_rpc_whitelist_enabled | lower }},
+    "rpc-host-whitelist": "{{ transmission_rpc_host_whitelist }}",
+    "rpc-host-whitelist-enabled": {{ transmission_rpc_host_whitelist_enabled | lower }},
     "scrape-paused-torrents-enabled": true,
     "script-torrent-done-enabled": false,
     "script-torrent-done-filename": "",


### PR DESCRIPTION
Adds support for the `rpc-host-whitelist-enabled` and `rpc-host-whitelist` [Transmission settings](https://github.com/transmission/transmission/wiki/Editing-Configuration-Files#rpc).  