### PR TITLE
Add rpc user variable (defaults to transmission_user)

### DIFF
--- a/templates/settings.json.j2
+++ b/templates/settings.json.j2
@@ -51,7 +51,7 @@
     "rpc-password": "{{ transmission_password }}",
     "rpc-port": {{ transmission_rpc_port }},
     "rpc-url": "{{ transmission_url }}",
-    "rpc-username": "{{ transmission_user }}",
+    "rpc-username": "{{ transmission_rpc_user | default(transmission_user) }}",
     "rpc-whitelist": "{{ transmission_rpc_whitelist }}",
     "rpc-whitelist-enabled": {{ transmission_rpc_whitelist_enabled | lower }},
     "rpc-host-whitelist": "{{ transmission_rpc_host_whitelist }}",


### PR DESCRIPTION
Allows to set `transmission_rpc_user` to set a RPC user different from the system user. Defaults to `transmission_user`.