### PR TITLE
Updated doc reference to transmission_rpc_user variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ There are no mandatory variables.
 
 ### Web interface & RPC
 
-| Variable                                  | Default                 |
-| ----------------------------------------- | ----------------------- |
-| `transmission_password`                   |                         |
-| `transmission_rpc_auth_required`          | `false`                 |
-| `transmission_user`                       | `{{ ansible_user_id }}` |
-| `transmission_rpc_whitelist_enabled`      | `true`                  |
-| `transmission_rpc_whitelist`              | `127.0.0.1`             |
-| `transmission_rpc_host_whitelist_enabled` | `true`                  |
-| `transmission_rpc_host_whitelist`         | `""`                    |
-| `transmission_url`                        | `/transmission/`        |
+| Variable                                  | Default                   |
+|-------------------------------------------|---------------------------|
+| `transmission_password`                   |                           |
+| `transmission_rpc_auth_required`          | `false`                   |
+| `transmission_rpc_user                    | `{{ transmission_user }}` |
+| `transmission_rpc_whitelist_enabled`      | `true`                    |
+| `transmission_rpc_whitelist`              | `127.0.0.1`               |
+| `transmission_rpc_host_whitelist_enabled` | `true`                    |
+| `transmission_rpc_host_whitelist`         | `""`                      |
+| `transmission_url`                        | `/transmission/`          |
 
 ### Folders
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 galaxy_info:
   author: Òscar Casajuana
+  role_name: transmission
   description: Transmission for debian based systems
   license: MIT
   min_ansible_version: 1.4


### PR DESCRIPTION
README documentation says that the `transmission_user`variable is the one to be used to connect with RPC, when it should be `transmission_rpc_user`.